### PR TITLE
Add Debian support and more parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This just installs the script/client only. You still need to do any certificate 
 
 Needs the following parameters:
 
- * `$acme_repo_path`
+ * `$acme_repo_path` -
  The full path to clone the acme.sh git repository in order to install from.
  (default: '/opt/acme_repo')
 
@@ -31,11 +31,14 @@ Needs the following parameters:
  The version/release of the acme git repository to clone.
  (default: 'master')
 
- * `$manage_dependencies`
+ * `$manage_dependencies` -
  Boolean to specify whether or not to install the required package dependencies.
  (default: false)
 
 ## Limitations
 
-Only *explicitly* tested on RHEL/CentOS 6 and Debian 7
+Only *explicitly* tested on RHEL/CentOS 6 and Debian 7.
 
+## Dependencies
+
+This module requires puppetlabs/vcsrepo.

--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ Needs the following parameters:
 
  * `$acme_repo_path`
  The full path to clone the acme.sh git repository in order to install from.
- (default: '/tmp/acme_sh')
+ (default: '/opt/acme_repo')
 
  * `$acme_home` -
  The full path to install the acme.sh script into (overriding $HOME/.acme.sh).
- (default: '/opt/acme/')
+ (default: '/opt/acme')
 
  * `$acme_certhome` -
  A customized dir to save the certs you issue.
@@ -26,6 +26,10 @@ Needs the following parameters:
  Specify the email address to be used in Letsencrypt API communications.
  This email address will later receive certificate expiry warnings.
  (default: undef)
+
+ * `$acme_version` -
+ The version/release of the acme git repository to clone.
+ (default: '2.3.0')
 
  * `$manage_dependencies`
  Boolean to specify whether or not to install the required package dependencies.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Needs the following parameters:
 
  * `$acme_version` -
  The version/release of the acme git repository to clone.
- (default: '2.3.0')
+ (default: 'master')
 
  * `$manage_dependencies`
  Boolean to specify whether or not to install the required package dependencies.

--- a/README.md
+++ b/README.md
@@ -8,16 +8,26 @@ This just installs the script/client only. You still need to do any certificate 
 
 ## Reference
 
-Needs two parameters:
+Needs the following parameters:
+
+ * `$acme_repo_path`
+ The full path to clone the acme.sh git repository in order to install from.
+ (default: '/tmp/acme_sh')
 
  * `$acme_home` -
  The full path to install the acme.sh script into (overriding $HOME/.acme.sh).
+ (default: '/opt/acme/')
 
  * `$accountemail` -
  Specify the email address to be used in Letsencrypt API communications.
  This email address will later receive certificate expiry warnings.
+ (default: undef)
+
+ * `$manage_dependencies`
+ Boolean to specify whether or not to install the required package dependencies.
+ (default: false)
 
 ## Limitations
 
-Only *explicitly* tested on RHEL/CentOS 6.
+Only *explicitly* tested on RHEL/CentOS 6 and Debian 7
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Needs the following parameters:
  The full path to install the acme.sh script into (overriding $HOME/.acme.sh).
  (default: '/opt/acme/')
 
+ * `$acme_certhome` -
+ A customized dir to save the certs you issue.
+ (default: $acme_home)
+
  * `$accountemail` -
  Specify the email address to be used in Letsencrypt API communications.
  This email address will later receive certificate expiry warnings.

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,6 +37,7 @@ class acme_sh (
   $acme_home           = $acme_sh::params::acme_home,
   $acme_certhome       = $acme_sh::params::acme_certhome,
   $acme_accountemail   = $acme_sh::params::acme_accountemail,
+  $acme_version        = $acme_sh::params::acme_version,
   $manage_dependencies = $acme_sh::params::manage_dependencies,
   ) inherits acme_sh::params {
 
@@ -50,14 +51,15 @@ class acme_sh (
   }
 
   vcsrepo {$acme_repo_path:
-    ensure   => latest,
+    ensure   => present,
     provider => git,
     source   => 'https://github.com/Neilpang/acme.sh.git',
+    revision => $acme_version,
     notify   => Exec['acme_sh::self-install'],
   }
 
   exec { 'acme_sh::self-install':
-    command     => "/bin/sh ./acme.sh --install --home ${acme_home} --certhome = ${acme_certhome} --accountemail \"${acme_accountemail}\"",
+    command     => "/bin/sh ./acme.sh --install --home ${acme_home} --certhome ${acme_certhome} --accountemail \"${acme_accountemail}\"",
     path        => ['/bin', '/usr/bin'],
     cwd         => $acme_repo_path,
     refreshonly => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,12 +6,18 @@
 # Parameters
 # ----------
 #
+# * `$acme_repo_path`
+# The full path to clone the acme.sh git repository in order to install from.
+#
 # * `$acme_home`
 # The full path to install the acme.sh script into (overriding $HOME/.acme.sh).
 #
 # * `$acme_accountemail`
 # Specify the email address to be used in Letsencrypt API communications.
 # This email address will later receive certificate expiry warnings.
+#
+# * `$manage_dependencies`
+# Boolean to specify whether or not to install the required package dependencies
 #
 # Authors
 # -------
@@ -23,44 +29,33 @@
 #
 # Apache 2.0
 #
-class acme_sh {
+class acme_sh (
+  $acme_repo_path      = $acme_sh::params::acme_repo_path,
+  $acme_home           = $acme_sh::params::acme_home,
+  $acme_accountemail   = $acme_sh::params::acme_accountemail,
+  $manage_dependencies = $acme_sh::params::manage_dependencies,
+  ) inherits acme_sh::params {
 
-  # install packages that are dependencies
-  if ! defined(Package['git']) {
-    package { 'git':
-      ensure => present,
-    }
+  validate_string($acme_home, $acme_accountemail)
+  validate_bool($manage_dependencies)
+
+  if $manage_dependencies {
+    $dependencies = ['git']
+    ensure_packages($dependencies)
+    Package[$dependencies] -> Vcsrepo[$acme_home]
   }
 
-  if ! defined(Package['nc']) {
-    package { 'nc':
-      ensure => present,
-    }
+  vcsrepo {'$acme_repo':
+    ensure   => latest,
+    provider => git,
+    source   => 'https://github.com/Neilpang/acme.sh.git',
+    notify   => Exec['acme_sh::self-install'],
   }
 
-  # clone acme.sh from git if not there at all
-  exec { 'acme_sh::git clone':
-    creates => '/tmp/.acme.sh',
-    command => 'git clone https://github.com/Neilpang/acme.sh.git /tmp/.acme.sh || (rmdir /tmp/.acme.sh && exit 1)',
-    path    => ['/bin', '/usr/bin'],
-    require => Package['git'],
-  }
-
-  # update (pull) from git if already there
-  exec { 'acme_sh::git pull':
-    onlyif  => 'test -f /tmp/.acme.sh/acme.sh',
-    command => 'git pull --rebase --stat origin master',
-    path    => ['/bin', '/usr/bin'],
-    cwd     => '/tmp/.acme.sh',
-    require => Package['git'],
-    notify  => Exec['acme_sh::self-install'],
-  }
-
-  # install/upgrade the script from the git source
   exec { 'acme_sh::self-install':
-    command     => "/bin/sh ./acme.sh --install  --home ${acme_home} --accountemail \"${acme_accountemail}\"",
+    command     => "/bin/sh ./acme.sh --install --home ${acme_home} --accountemail \"${acme_accountemail}\"",
     path        => ['/bin', '/usr/bin'],
-    cwd         => '/tmp/.acme.sh',
+    cwd         => $acme_,
     refreshonly => true,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class acme_sh (
   exec { 'acme_sh::self-install':
     command     => "/bin/sh ./acme.sh --install --home ${acme_home} --accountemail \"${acme_accountemail}\"",
     path        => ['/bin', '/usr/bin'],
-    cwd         => $acme_,
+    cwd         => $acme_repo_path,
     refreshonly => true,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,10 +42,10 @@ class acme_sh (
   if $manage_dependencies {
     $dependencies = ['git']
     ensure_packages($dependencies)
-    Package[$dependencies] -> Vcsrepo[$acme_home]
+    Package[$dependencies] -> Vcsrepo[$acme_repo_path]
   }
 
-  vcsrepo {'$acme_repo':
+  vcsrepo {$acme_repo_path:
     ensure   => latest,
     provider => git,
     source   => 'https://github.com/Neilpang/acme.sh.git',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -12,6 +12,9 @@
 # * `$acme_home`
 # The full path to install the acme.sh script into (overriding $HOME/.acme.sh).
 #
+# * `$acme_certhome`
+# A customized dir to save the certs you issue. By default, it saves the certs in $acme_home
+#
 # * `$acme_accountemail`
 # Specify the email address to be used in Letsencrypt API communications.
 # This email address will later receive certificate expiry warnings.
@@ -32,6 +35,7 @@
 class acme_sh (
   $acme_repo_path      = $acme_sh::params::acme_repo_path,
   $acme_home           = $acme_sh::params::acme_home,
+  $acme_certhome       = $acme_sh::params::acme_certhome,
   $acme_accountemail   = $acme_sh::params::acme_accountemail,
   $manage_dependencies = $acme_sh::params::manage_dependencies,
   ) inherits acme_sh::params {
@@ -53,7 +57,7 @@ class acme_sh (
   }
 
   exec { 'acme_sh::self-install':
-    command     => "/bin/sh ./acme.sh --install --home ${acme_home} --accountemail \"${acme_accountemail}\"",
+    command     => "/bin/sh ./acme.sh --install --home ${acme_home} --certhome = ${acme_certhome} --accountemail \"${acme_accountemail}\"",
     path        => ['/bin', '/usr/bin'],
     cwd         => $acme_repo_path,
     refreshonly => true,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -41,7 +41,7 @@ class acme_sh (
   $manage_dependencies = $acme_sh::params::manage_dependencies,
   ) inherits acme_sh::params {
 
-  validate_string($acme_home, $acme_accountemail)
+  validate_string($acme_repo_path, $acme_home, $acme_certhome, $acme_accountemail)
   validate_bool($manage_dependencies)
 
   if $manage_dependencies {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,8 +1,9 @@
 class acme_sh::params {
-  $acme_repo_path      = '/tmp/acme_sh'
-  $acme_home           = '/opt/acme/'
+  $acme_repo_path      = '/opt/acme_repo'
+  $acme_home           = '/opt/acme'
   $acme_certhome       = $acme_home
   $acme_accountemail   = undef
+  $acme_version        = '2.3.0'
   $manage_dependencies = false
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,7 @@
 class acme_sh::params {
   $acme_repo_path      = '/tmp/acme_sh'
   $acme_home           = '/opt/acme/'
+  $acme_certhome       = $acme_home
   $acme_accountemail   = undef
   $manage_dependencies = false
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@ class acme_sh::params {
   $acme_home           = '/opt/acme'
   $acme_certhome       = $acme_home
   $acme_accountemail   = undef
-  $acme_version        = '2.3.0'
+  $acme_version        = 'master'
   $manage_dependencies = false
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,0 +1,7 @@
+class acme_sh::params {
+  $acme_repo_path      = '/tmp/acme.sh'
+  $acme_home           = '/opt/acme/'
+  $acme_accountemail   = undef
+  $manage_dependencies = false
+}
+

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 class acme_sh::params {
-  $acme_repo_path      = '/tmp/acme.sh'
+  $acme_repo_path      = '/tmp/acme_sh'
   $acme_home           = '/opt/acme/'
   $acme_accountemail   = undef
   $manage_dependencies = false

--- a/metadata.json
+++ b/metadata.json
@@ -18,7 +18,14 @@
     }
   ],
   "operatingsystem_support": [
-    {"operatingsystem":"RedHat","operatingsystemrelease":[ "6.0" ]}
+    { 
+      "operatingsystem":"RedHat",
+      "operatingsystemrelease":[ "6.0" ]
+    }
+    { 
+      "operatingsystem":"Debian",
+      "operatingsystemrelease":[ "7" ]
+    }
   ],
   "data_provider": null
 }

--- a/metadata.json
+++ b/metadata.json
@@ -9,7 +9,7 @@
   "issues_url": "https://github.com/techdad/puppet-acme_sh/issues",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0 < 5.0.0"},
-    {"name":"puppetlabs-vcsrepo","version_requirement":">=">= 1.3.2"}
+    {"name":"puppetlabs-vcsrepo","version_requirement":">= 1.3.2"}
   ],
   "operatingsystem_support": [
     {

--- a/metadata.json
+++ b/metadata.json
@@ -8,21 +8,15 @@
   "project_page": "https://github.com/techdad/puppet-acme_sh",
   "issues_url": "https://github.com/techdad/puppet-acme_sh/issues",
   "dependencies": [
-    {
-      "name":"puppetlabs-stdlib",
-      "version_requirement":">= 4.0.0 < 5.0.0"
-    },
-    {
-      "name":"puppetlabs-vcsrepo",
-      "version_requirement":">=">= 1.3.2"
-    }
+    {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0 < 5.0.0"},
+    {"name":"puppetlabs-vcsrepo","version_requirement":">=">= 1.3.2"}
   ],
   "operatingsystem_support": [
-    { 
+    {
       "operatingsystem":"RedHat",
       "operatingsystemrelease":[ "6.0" ]
     },
-    { 
+    {
       "operatingsystem":"Debian",
       "operatingsystemrelease":[ "7" ]
     }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "techdad-acme_sh",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "author": "techdad",
   "summary": "Install acme.sh LE client from https://github.com/Neilpang/acme.sh",
   "license": "Apache-2.0",
@@ -11,7 +11,7 @@
     {
       "name":"puppetlabs-stdlib",
       "version_requirement":">= 4.0.0 < 5.0.0"
-    }
+    },
     {
       "name":"puppetlabs-vcsrepo",
       "version_requirement":">=">= 1.3.2"
@@ -21,7 +21,7 @@
     { 
       "operatingsystem":"RedHat",
       "operatingsystemrelease":[ "6.0" ]
-    }
+    },
     { 
       "operatingsystem":"Debian",
       "operatingsystemrelease":[ "7" ]

--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,14 @@
   "project_page": "https://github.com/techdad/puppet-acme_sh",
   "issues_url": "https://github.com/techdad/puppet-acme_sh/issues",
   "dependencies": [
-    {"name":"puppetlabs-stdlib","version_requirement":">= 4.0.0 < 5.0.0"}
+    {
+      "name":"puppetlabs-stdlib",
+      "version_requirement":">= 4.0.0 < 5.0.0"
+    }
+    {
+      "name":"puppetlabs-vcsrepo",
+      "version_requirement":">=">= 1.3.2"
+    }
   ],
   "operatingsystem_support": [
     {"operatingsystem":"RedHat","operatingsystemrelease":[ "6.0" ]}


### PR DESCRIPTION
- Confirmed testing works on Debian Wheezy (7)
- Make module properly parameter driven and add additional params to manipulate repo and certificate paths
- Use vcsrepo module to control git repo installation
