### PR TITLE
Ensure acme_home is created when accidentally removed

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,10 +59,10 @@ class acme_sh (
   }
 
   exec { 'acme_sh::self-install':
-    command     => "/bin/sh ./acme.sh --install --home ${acme_home} --certhome ${acme_certhome} --accountemail \"${acme_accountemail}\"",
-    path        => ['/bin', '/usr/bin'],
-    cwd         => $acme_repo_path,
-    refreshonly => true,
+    command => "/bin/sh ./acme.sh --install --home ${acme_home} --certhome ${acme_certhome} --accountemail \"${acme_accountemail}\"",
+    path    => ['/bin', '/usr/bin'],
+    cwd     => $acme_repo_path,
+    creates => $acme_home,
   }
 
 }


### PR DESCRIPTION
* Replace refreshonly for the exec that installs acme with creates which will ensure the acme is installed when the repo is cloned as well as when deleted for whatever reason.