### PR TITLE
enable the ability to not provision the cronjob

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,6 +22,9 @@
 # * `$manage_dependencies`
 # Boolean to specify whether or not to install the required package dependencies
 #
+# * `$acme_cron_enable`
+# Boolean to specify whether or not to install the cron job on install
+#
 # Authors
 # -------
 #
@@ -41,12 +44,19 @@ class acme_sh (
   String $acme_accountemail   = $acme_sh::params::acme_accountemail,
   String $acme_version        = $acme_sh::params::acme_version,
   Boolean $manage_dependencies = $acme_sh::params::manage_dependencies,
+  Boolean $acme_cron_enable   = $acme_sh::params::acme_cron_enable,
   ) inherits acme_sh::params {
 
   if $manage_dependencies {
     $dependencies = ['git']
     ensure_packages($dependencies)
     Package[$dependencies] -> Vcsrepo[$acme_repo_path]
+  }
+
+  if $acme_cron_enable {
+    $acme_cron = ''
+  } else {
+    $acme_cron = '--no-cron'
   }
 
   vcsrepo {$acme_repo_path:
@@ -58,7 +68,7 @@ class acme_sh (
   }
 
   exec { 'acme_sh::self-install':
-    command => "/bin/sh ./acme.sh --install --home ${acme_home} --certhome ${acme_certhome} --accountemail \"${acme_accountemail}\"",
+    command => "/bin/sh ./acme.sh --install ${$acme_cron} --home ${acme_home} --certhome ${acme_certhome} --accountemail \"${acme_accountemail}\"",
     path    => ['/bin', '/usr/bin'],
     cwd     => $acme_repo_path,
     creates => $acme_home,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,5 +9,6 @@ class acme_sh::params {
   $acme_accountemail   = undef
   $acme_version        = 'master'
   $manage_dependencies = false
+  $acme_cron_enable    = true
 }
 


### PR DESCRIPTION
This is useful for cases where you want to manage the cronjob with puppet, and do not want duplicate cron jobs.